### PR TITLE
Fix nested list at outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -14,11 +14,11 @@ output "acm_certificate_domain_validation_options" {
 }
 
 output "route53_record_fqdns" {
-  value       = [aws_route53_record.default.*.fqdn]
+  value       = aws_route53_record.default.*.fqdn
   description = "FQDN built using the zone domain and name."
 }
 
 output "route53_record_names" {
-  value       = [aws_route53_record.default.*.name]
+  value       = aws_route53_record.default.*.name
   description = "The name of the record."
 }


### PR DESCRIPTION
## Before

```
route53_record_fqdns = [
  [
    "_xxxx.example.com",
    "_yyyy.stg.example.com",
    "_zzzz.dev.example.com",
  ],
]
route53_record_names = [
  [
    "_xxxx.example.com",
    "_yyyy.stg.example.com",
    "_zzzz.dev.example.com",
  ],
]
```

## After

```
route53_record_fqdns = [
  "_xxxx.example.com",
  "_yyyy.stg.example.com",
  "_zzzz.dev.example.com",
]
route53_record_names = [
  "_xxxx.example.com",
  "_yyyy.stg.example.com",
  "_zzzz.dev.example.com",
]
```